### PR TITLE
[BUGFIX] Decode base64 files and run textFor on them

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@types/node": "*"
+    "mime-types": "^2.1.20"
   },
   "devDependencies": {
-    "@types/node": "^10.5.5",
     "@krisselden/har-schema": "^0.1.0",
+    "@types/mime-types": "^2.1.0",
+    "@types/node": "^10.5.5",
     "json-schema-to-typescript": "^5.5.0",
     "tslint": "^5.11.0",
     "typescript": "^3.0.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,6 @@ export default class ArchiveServer {
       let { text, encoding, mimeType } = content;
       let body: Buffer | undefined;
 
-      let isText = mimeType.match(/text|javascript/) !== null;
-
       if (text === undefined) {
         body = undefined;
       } else if (mimeTypes.charset(mimeType) === 'UTF-8') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,10 @@
   version "4.14.116"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
 
+"@types/mime-types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
+
 "@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
@@ -317,6 +321,16 @@ memoizee@^0.4.3:
     lru-queue "0.1"
     next-tick "1"
     timers-ext "^0.1.2"
+
+mime-db@~1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+
+mime-types@^2.1.20:
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
+  dependencies:
+    mime-db "~1.36.0"
 
 minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This PR moves the base64 handling to happen before `textFor`. Recent HAR files appear to save large javascript files as base64, this makes them usable.